### PR TITLE
Fix Sass deprecation warnings in stylesheets and themes

### DIFF
--- a/src/stylesheets/app-direct.scss
+++ b/src/stylesheets/app-direct.scss
@@ -1,3 +1,9 @@
+@use 'iconfont';
+@use 'buttons';
+@use 'social_links';
+@use 'downloads';
+@use 'transcript_search';
+
 *,
 *:before,
 *:after {
@@ -5,9 +11,3 @@
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
-
-@import 'iconfont';
-@import 'buttons';
-@import 'social_links';
-@import 'downloads';
-@import 'transcript_search';

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -1,12 +1,12 @@
+@use 'iconfont';
+@use 'buttons';
+@use 'embed';
+@use 'social_links';
+@use 'downloads';
+@use 'transcript_search';
+
 *, *:before, *:after {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
-
-@import 'iconfont';
-@import 'buttons';
-@import 'embed';
-@import 'social_links';
-@import 'downloads';
-@import 'transcript_search';

--- a/src/stylesheets/buttons.scss
+++ b/src/stylesheets/buttons.scss
@@ -1,3 +1,5 @@
+@use 'iconfont';
+
 .play-button {
   @extend .icon;
   @extend .icon-play;

--- a/src/stylesheets/icon-vars.scss
+++ b/src/stylesheets/icon-vars.scss
@@ -1,0 +1,25 @@
+$icomoon-font-path: "../fonts" !default;
+
+$icon-cast: "\e307";
+$icon-close: "\e5cd";
+$icon-download: "\e2c0";
+$icon-chaptermarks: "\e431";
+$icon-error_outline: "\e001";
+$icon-transcript: "\e236";
+$icon-forward_30: "\e057";
+$icon-episode-info: "\e88f";
+$icon-keyboard_arrow_left: "\e314";
+$icon-keyboard_arrow_right: "\e315";
+$icon-playlist: "\e896";
+$icon-mail_outline: "\e0e1";
+$icon-pause: "\e034";
+$icon-play: "\e037";
+$icon-backward_10: "\e059";
+$icon-share: "\e80d";
+$icon-skip_next: "\e044";
+$icon-skip_previous: "\e045";
+$icon-twitter: "\f099";
+$icon-facebook: "\f09a";
+$icon-facebook-f: "\f09a";
+$icon-google-plus: "\f0d5";
+$icon-whatsapp: "\f232";

--- a/src/stylesheets/iconfont.scss
+++ b/src/stylesheets/iconfont.scss
@@ -1,34 +1,10 @@
-$icomoon-font-path: "../fonts" !default;
-
-$icon-cast: "\e307";
-$icon-close: "\e5cd";
-$icon-download: "\e2c0";
-$icon-chaptermarks: "\e431";
-$icon-error_outline: "\e001";
-$icon-transcript: "\e236";
-$icon-forward_30: "\e057";
-$icon-episode-info: "\e88f";
-$icon-keyboard_arrow_left: "\e314";
-$icon-keyboard_arrow_right: "\e315";
-$icon-playlist: "\e896";
-$icon-mail_outline: "\e0e1";
-$icon-pause: "\e034";
-$icon-play: "\e037";
-$icon-backward_10: "\e059";
-$icon-share: "\e80d";
-$icon-skip_next: "\e044";
-$icon-skip_previous: "\e045";
-$icon-twitter: "\f099";
-$icon-facebook: "\f09a";
-$icon-facebook-f: "\f09a";
-$icon-google-plus: "\f0d5";
-$icon-whatsapp: "\f232";
+@use 'icon-vars';
 
 @font-face {
   font-family: 'podigee-podcast-player';
-  src: url('#{$icomoon-font-path}/podigee-podcast-player.ttf?kq1u8x') format('truetype'),
-    url('#{$icomoon-font-path}/podigee-podcast-player.woff?kq1u8x') format('woff'),
-    url('#{$icomoon-font-path}/podigee-podcast-player.svg?kq1u8x#podigee-podcast-player') format('svg');
+  src: url('#{icon-vars.$icomoon-font-path}/podigee-podcast-player.ttf?kq1u8x') format('truetype'),
+    url('#{icon-vars.$icomoon-font-path}/podigee-podcast-player.woff?kq1u8x') format('woff'),
+    url('#{icon-vars.$icomoon-font-path}/podigee-podcast-player.svg?kq1u8x#podigee-podcast-player') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -50,116 +26,116 @@ $icon-whatsapp: "\f232";
 
 .icon-cast {
   &:before {
-    content: $icon-cast;
+    content: icon-vars.$icon-cast;
   }
 }
 .icon-close {
   &:before {
-    content: $icon-close;
+    content: icon-vars.$icon-close;
   }
 }
 .icon-download {
   &:before {
-    content: $icon-download;
+    content: icon-vars.$icon-download;
   }
 }
 .icon-chaptermarks {
   &:before {
-    content: $icon-chaptermarks;
+    content: icon-vars.$icon-chaptermarks;
   }
 }
 .icon-error_outline {
   &:before {
-    content: $icon-error_outline;
+    content: icon-vars.$icon-error_outline;
   }
 }
 .icon-transcript {
   &:before {
-    content: $icon-transcript;
+    content: icon-vars.$icon-transcript;
   }
 }
 .icon-forward-30 {
   &:before {
-    content: $icon-forward_30;
+    content: icon-vars.$icon-forward_30;
   }
 }
 .icon-episode-info {
   &:before {
-    content: $icon-episode-info;
+    content: icon-vars.$icon-episode-info;
   }
 }
 .icon-keyboard_arrow_left {
   &:before {
-    content: $icon-keyboard_arrow_left;
+    content: icon-vars.$icon-keyboard_arrow_left;
   }
 }
 .icon-keyboard_arrow_right {
   &:before {
-    content: $icon-keyboard_arrow_right;
+    content: icon-vars.$icon-keyboard_arrow_right;
   }
 }
 .icon-playlist {
   &:before {
-    content: $icon-playlist;
+    content: icon-vars.$icon-playlist;
   }
 }
 .icon-mail_outline {
   &:before {
-    content: $icon-mail_outline;
+    content: icon-vars.$icon-mail_outline;
   }
 }
 .icon-pause {
   &:before {
-    content: $icon-pause;
+    content: icon-vars.$icon-pause;
   }
 }
 .icon-play {
   &:before {
-    content: $icon-play;
+    content: icon-vars.$icon-play;
   }
 }
 .icon-backward-10 {
   &:before {
-    content: $icon-backward_10;
+    content: icon-vars.$icon-backward_10;
   }
 }
 .icon-share {
   &:before {
-    content: $icon-share;
+    content: icon-vars.$icon-share;
   }
 }
 .icon-skip-next {
   &:before {
-    content: $icon-skip_next;
+    content: icon-vars.$icon-skip_next;
   }
 }
 .icon-skip-previous {
   &:before {
-    content: $icon-skip_previous;
+    content: icon-vars.$icon-skip_previous;
   }
 }
 .icon-twitter {
   &:before {
-    content: $icon-twitter;
+    content: icon-vars.$icon-twitter;
   }
 }
 .icon-facebook {
   &:before {
-    content: $icon-facebook;
+    content: icon-vars.$icon-facebook;
   }
 }
 .icon-facebook-f {
   &:before {
-    content: $icon-facebook-f;
+    content: icon-vars.$icon-facebook-f;
   }
 }
 .icon-google-plus {
   &:before {
-    content: $icon-google-plus;
+    content: icon-vars.$icon-google-plus;
   }
 }
 .icon-whatsapp {
   &:before {
-    content: $icon-whatsapp;
+    content: icon-vars.$icon-whatsapp;
   }
 }

--- a/src/stylesheets/social_links.scss
+++ b/src/stylesheets/social_links.scss
@@ -1,3 +1,6 @@
+@use 'iconfont';
+@use 'icon-vars';
+
 .panels .share-social-links {
   list-style: none;
   padding: 0;
@@ -48,25 +51,25 @@
 
   .share-link-facebook:before {
     background: rgb(59, 89, 152);
-    content: $icon-facebook;
+    content: icon-vars.$icon-facebook;
     padding: 8px 14px;
   }
 
   .share-link-twitter:before {
     background: rgb(0, 172, 237);
-    content: $icon-twitter;
+    content: icon-vars.$icon-twitter;
     padding: 8px 9px;
   }
 
   .share-link-whatsapp:before {
     background: rgb(67, 216, 84);
-    content: $icon-whatsapp;
+    content: icon-vars.$icon-whatsapp;
     padding: 8px 10px;
   }
 
   .share-link-email:before {
     background: rgb(153, 153, 153);
-    content: $icon-mail-outline;
+    content: icon-vars.$icon-mail-outline;
     padding: 8px 8px;
   }
 }

--- a/src/themes/default-dark/index.scss
+++ b/src/themes/default-dark/index.scss
@@ -1,5 +1,14 @@
-@import 'variables';
-@import '../default/index';
+@use 'variables' as dark-vars;
+@use '../default/index' with (
+  $default-padding: dark-vars.$default-padding,
+  $background-color: dark-vars.$background-color,
+  $default-color: dark-vars.$default-color,
+  $light-grey: dark-vars.$light-grey,
+  $dark-grey: dark-vars.$dark-grey,
+  $highlight1: dark-vars.$highlight1,
+  $highlight2: dark-vars.$highlight2,
+  $transcript-highlight: dark-vars.$transcript-highlight
+);
 
 .podcast-player {
   .panels {
@@ -7,18 +16,18 @@
     .chaptermarks ul li:hover,
     .playlist ul li.active,
     .playlist ul li:hover {
-      color: $background-color;
+      color: dark-vars.$background-color;
     }
 
     .share .share-copy-url {
-      color: $default-color;
+      color: dark-vars.$default-color;
     }
 
     .transcript .transcript-text li {
       &:hover > *,
       &.active > *,
       &.search-highlight > * {
-        color: $background-color;
+        color: dark-vars.$background-color;
       }
     }
   }

--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -1,5 +1,6 @@
 @use 'sass:color';
-@import 'variables';
+@forward 'variables';
+@use 'variables';
 
 .podcast-player {
   &,
@@ -11,7 +12,7 @@
     box-sizing: border-box;
   }
 
-  background-color: $background-color;
+  background-color: variables.$background-color;
   color: #222;
   font-family: Helvetica;
   min-width: 100%;
@@ -20,7 +21,7 @@
   width: 1px;
 
   a {
-    color: $highlight1;
+    color: variables.$highlight1;
     text-decoration: none;
 
     &:hover {
@@ -41,12 +42,12 @@
 
   .episode-basic-info {
     max-height: 90px;
-    padding: 23px $default-padding 0;
+    padding: 23px variables.$default-padding 0;
     position: relative;
     overflow: hidden;
 
     .episode-title {
-      color: $highlight1;
+      color: variables.$highlight1;
       font-size: 18px;
       font-weight: 600;
       line-height: 1.4em;
@@ -57,7 +58,7 @@
     }
 
     .episode-subtitle {
-      color: $default-color;
+      color: variables.$default-color;
       font-size: 16px;
       min-height: 18px;
       overflow: hidden;
@@ -83,9 +84,9 @@
     height: 90px;
 
     .play-button {
-      border: 3px solid $light-grey;
+      border: 3px solid variables.$light-grey;
       border-radius: 100px;
-      color: $dark-grey;
+      color: variables.$dark-grey;
       font-size: 56px;
       height: 70px;
       margin: 10px 0 0 10px;
@@ -100,12 +101,12 @@
     position: absolute;
 
     button {
-      color: $dark-grey;
+      color: variables.$dark-grey;
       font-size: 18px;
     }
 
     button:hover {
-      color: $highlight1;
+      color: variables.$highlight1;
     }
 
     .speed-select {
@@ -114,7 +115,7 @@
       appearance: none;
       border: 0;
       background-color: transparent;
-      color: $dark-grey;
+      color: variables.$dark-grey;
       font-size: 14px;
       outline: 0;
       position: relative;
@@ -135,7 +136,7 @@
     overflow: hidden;
 
     .progress-bar-time-played {
-      color: $dark-grey;
+      color: variables.$dark-grey;
       cursor: pointer;
       font-size: 14px;
       left: 85px;
@@ -146,11 +147,11 @@
     }
 
     .progress-bar-time-played:hover {
-      color: $highlight1;
+      color: variables.$highlight1;
     }
 
     .progress-bar-rail {
-      background-color: $light-grey;
+      background-color: variables.$light-grey;
       cursor: ew-resize;
       min-height: 10px;
       overflow: hidden;
@@ -164,7 +165,7 @@
 
   .progress-bar-played,
   .progress-bar-loaded {
-    background-color: $highlight2;
+    background-color: variables.$highlight2;
     display: block;
     height: 100%;
     position: absolute;
@@ -173,7 +174,7 @@
   }
 
   .progress-bar-loaded {
-    background-color: $dark-grey;
+    background-color: variables.$dark-grey;
   }
 
   .progress-bar-buffering {
@@ -221,7 +222,7 @@
     top: 68px;
 
     button {
-      color: $dark-grey;
+      color: variables.$dark-grey;
       display: inline-block;
       font-size: 16px;
       text-align: center;
@@ -230,7 +231,7 @@
 
     button:hover,
     button.button-active {
-      color: $highlight1;
+      color: variables.$highlight1;
     }
 
     img {
@@ -239,7 +240,7 @@
   }
 
   .panels {
-    color: $default-color;
+    color: variables.$default-color;
     font-size: 14px;
     font-weight: 300;
     height: auto;
@@ -248,7 +249,7 @@
     & > div {
       height: 100%;
       overflow: hidden;
-      padding: 0 0 0 $default-padding;
+      padding: 0 0 0 variables.$default-padding;
       position: relative;
     }
 
@@ -280,15 +281,15 @@
           width: 100%;
 
           & + li {
-            border-top: 1px solid $light-grey;
+            border-top: 1px solid variables.$light-grey;
           }
 
           &:hover {
-            background-color: $light-grey;
+            background-color: variables.$light-grey;
           }
 
           &.active {
-            background-color: color.adjust($highlight2, $lightness: 55%);
+            background-color: color.adjust(variables.$highlight2, $lightness: 55%);
           }
 
           img {
@@ -331,7 +332,7 @@
             width: 13px;
 
             svg {
-              color: $default-color;
+              color: variables.$default-color;
               fill: currentColor;
             }
           }
@@ -433,7 +434,7 @@
           }
 
           &.search-highlight > * {
-            background-color: $transcript-search-highlight;
+            background-color: variables.$transcript-search-highlight;
           }
         }
       }
@@ -494,9 +495,9 @@
 
 .podcast-player.mode-script,
 .podcast-player.mode-direct {
-  @media (max-width: $mobile-breakpoint) {
+  @media (max-width: variables.$mobile-breakpoint) {
     .cover-image {
-      border: 12px solid $background-color;
+      border: 12px solid variables.$background-color;
       border-bottom: 0;
       display: none;
       float: none;
@@ -612,7 +613,7 @@
 }
 
 .podcast-player.mode-iframe {
-  @media (max-width: $mobile-breakpoint) {
+  @media (max-width: variables.$mobile-breakpoint) {
     .cover-image {
       display: none;
     }

--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import 'variables';
 
 .podcast-player {
@@ -287,7 +288,7 @@
           }
 
           &.active {
-            background-color: lighten($highlight2, 55%);
+            background-color: color.adjust($highlight2, $lightness: 55%);
           }
 
           img {

--- a/src/themes/legacy/index.scss
+++ b/src/themes/legacy/index.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import 'variables';
+@use 'variables';
 
 .podcast-player {
   &, *, *:before, *:after {
@@ -9,7 +9,7 @@
   }
 
   background: linear-gradient(to bottom, rgb(84, 84, 84) 0%, rgb(38, 38, 38) 100%);
-  color: $default-color;
+  color: variables.$default-color;
   font-family: Helvetica, Arial, sans-serif;
   min-width: 100%;
   overflow: hidden;
@@ -17,11 +17,11 @@
   width: 1px;
 
   a {
-    color: $default-color;
+    color: variables.$default-color;
     text-decoration: none;
 
     &:hover {
-      color: $highlight2;
+      color: variables.$highlight2;
       text-decoration: underline;
     }
   }
@@ -38,9 +38,9 @@
     height: 90px;
 
     .play-button {
-      border: 3px solid $light-grey;
+      border: 3px solid variables.$light-grey;
       border-radius: 100px;
-      color: $dark-grey;
+      color: variables.$dark-grey;
       font-size: 56px;
       height: 70px;
       margin: 10px 0 0 10px;
@@ -48,8 +48,8 @@
       width: 70px;
 
       &:hover {
-        color: $default-color;
-        border-color: $default-color;;
+        color: variables.$default-color;
+        border-color: variables.$default-color;;
       }
     }
 
@@ -60,12 +60,12 @@
       top: 66px;
 
       button {
-        color: $dark-grey;
+        color: variables.$dark-grey;
         font-size: 14px;
       }
 
       button:hover {
-        color: $highlight1;
+        color: variables.$highlight1;
       }
 
       .speed-toggle {
@@ -83,7 +83,7 @@
   .episode-basic-info {
     float: left;
     max-height: 90px;
-    padding: 5px $default-padding 0;
+    padding: 5px variables.$default-padding 0;
     position: relative;
     overflow: hidden;
     width: calc(100% - 170px);
@@ -114,7 +114,7 @@
     padding: 0 5px;
 
     .progress-bar-time-played {
-      color: $dark-grey;
+      color: variables.$dark-grey;
       cursor: pointer;
       float: left;
       font-size: 12px;
@@ -124,11 +124,11 @@
     }
 
     .progress-bar-time-played:hover {
-      color: $default-color;
+      color: variables.$default-color;
     }
 
     .progress-bar-rail {
-      background-color: $light-grey;
+      background-color: variables.$light-grey;
       cursor: ew-resize;
       min-height: 10px;
       overflow: hidden;
@@ -139,7 +139,7 @@
 
   .progress-bar-played,
   .progress-bar-loaded {
-    background-color: $highlight2;
+    background-color: variables.$highlight2;
     display: block;
     height: 100%;
     position: absolute;
@@ -148,7 +148,7 @@
   }
 
   .progress-bar-loaded {
-    background-color: $dark-grey;
+    background-color: variables.$dark-grey;
   }
 
   .progress-bar-buffering {
@@ -191,7 +191,7 @@
     top: 68px;
 
     button {
-      color: $dark-grey;
+      color: variables.$dark-grey;
       display: inline-block;
       font-size: 16px;
       text-align: center;
@@ -200,7 +200,7 @@
 
     button:hover,
     button.button-active {
-      color: $default-color;
+      color: variables.$default-color;
     }
 
     img {
@@ -209,7 +209,7 @@
   }
 
   .panels {
-    color: $default-color;
+    color: variables.$default-color;
     font-size: 14px;
     font-weight: 300;
     height: 400px;
@@ -218,7 +218,7 @@
     & > div {
       height: 100%;
       overflow: hidden;
-      padding: 0 0 0 $default-padding;
+      padding: 0 0 0 variables.$default-padding;
       position: relative;
     }
 
@@ -246,17 +246,17 @@
           position: relative;
 
           & + li {
-            border-top: 1px solid $light-grey;
+            border-top: 1px solid variables.$light-grey;
           }
 
           &:hover {
-            background-color: $light-grey;
-            color: $background-color;
+            background-color: variables.$light-grey;
+            color: variables.$background-color;
           }
 
           &.active {
-            background-color: color.adjust($highlight2, $lightness: 55%);
-            color: $background-color;
+            background-color: color.adjust(variables.$highlight2, $lightness: 55%);
+            color: variables.$background-color;
           }
 
           img {
@@ -281,7 +281,7 @@
           }
 
           a {
-            color: $highlight2;
+            color: variables.$highlight2;
             font-size: 16px;
             right: 5px;
             position: absolute;
@@ -326,7 +326,7 @@
         background: transparent;
         border: 1px solid #ccc;
         border-radius: 3px;
-        color: $default-color;
+        color: variables.$default-color;
         font-size: 20px;
         outline: none;
         padding: 4px;
@@ -351,8 +351,8 @@
 
           &:hover > *,
           &.active > * {
-            background-color: $transcript-highlight;
-            color: $background-color;
+            background-color: variables.$transcript-highlight;
+            color: variables.$background-color;
           }
         }
       }

--- a/src/themes/legacy/index.scss
+++ b/src/themes/legacy/index.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import 'variables';
 
 .podcast-player {
@@ -254,7 +255,7 @@
           }
 
           &.active {
-            background-color: lighten($highlight2, 55%);
+            background-color: color.adjust($highlight2, $lightness: 55%);
             color: $background-color;
           }
 


### PR DESCRIPTION
## Summary

`make build` previously emitted dozens of Sass deprecation warnings on every run, in two classes:
- `[global-builtin]` and `[color-functions]` from calls to the legacy `lighten()` function (will be removed in Dart Sass 3.0)
- `[import]` from `@import` statements throughout the stylesheets and themes (will be removed in Dart Sass 3.0)

This branch eliminates all of them. After the change, the only deprecation line still printed during `make build` is the unrelated `[DEP0169]` Node warning from `yarn install` itself (`url.parse()` inside one of yarn 1.22's transitive deps), which is out of scope.

## Commits

1. **`Replace deprecated lighten() with color.adjust()`** — hand edit of the two callsites in `themes/default/index.scss` and `themes/legacy/index.scss`. `color.adjust($color, \$lightness: 55%)` is the documented forward-compatible replacement and produces an identical computed color.
2. **`Migrate @import to @use for Sass 3.0 compatibility`** — driven by the official `sass-migrator module --migrate-deps` tool, plus a few hand-written changes the migrator couldn't resolve automatically:
   - Split `iconfont.scss` into a variables-only partial (`icon-vars.scss`) consumed by both `iconfont.scss` and `social_links.scss` — the migrator refused to hoist a "late" import that also emitted CSS.
   - Manually rewrote `themes/default-dark/index.scss` to thread its variable overrides through `@use '../default/index' with (...)` configuration instead of relying on `@import`-order + `!default`. `themes/default/index.scss` adds `@forward 'variables';` so its variables remain configurable downstream.
   - `buttons.scss` and `social_links.scss` now `@use 'iconfont';` so their `@extend .icon` / `@extend .icon-*` keep resolving across the module boundary; Sass deduplicates the module against the entry point's own `@use`.
   - The `*, *:before, *:after` reset in `app.scss` and `app-direct.scss` moves below the `@use` statements (Sass requires `@use` rules to come first); both rules carry specificity 0 so the cascade is unchanged.

## CSS impact

- `build/themes/**` is **byte-identical** to the previous build.
- `build/stylesheets/{app,app-direct}.css` differ only in:
  - The box-sizing reset's position (now end-of-file).
  - Loss of one dead extended selector — `.panels .download .download-button` — that never matched in the DOM because the download button is rendered into the controls bar, not into `.panels .download`.

## Test plan

- [x] `make build` exits 0
- [x] `make build 2>&1 | grep -i "deprecation warning \["` returns no matches
- [x] `diff -rq build/themes /tmp/build-before/themes` is empty (byte-identical theme output)
- [x] The lightened-active-row background renders the equivalent color (`rgb(237.2, 249.3, 248.2)`) in both default and legacy themes
- [ ] Smoke-test the player in a browser — the icon font, share links, download button, and dark theme should all render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)